### PR TITLE
Update to use offline-capable did-veres-one driver.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@digitalbazaar/did-io": "^1.0.0",
     "@digitalbazaar/did-method-key": "^2.0.0",
-    "did-veres-one": "14.0.0-beta.1",
+    "did-veres-one": "veres-one/did-veres-one#rc14.1.0-beta.0",
     "esm": "^3.2.25"
   },
   "peerDependencies": {


### PR DESCRIPTION
Allows downstream document resolvers to use `driver.getInitial()` instead of `.get()`, which allows fetching unregistered VeresOne DIDs in offline mode.